### PR TITLE
[fix] wrong grid-template-areas css being rendered

### DIFF
--- a/src/Text/CSS/Property.idr
+++ b/src/Text/CSS/Property.idr
@@ -65,7 +65,7 @@ namespace Display
       col : Vect (S n) a -> String
       col vs =
         let str := concat . intersperse " " . map showTag $ toList vs
-         in "\{str}"
+         in #""\#{str}""#
 
 namespace FlexBasis
   public export


### PR DESCRIPTION
I was checking out this fantastic library but noticed the examples were broken.
![image](https://github.com/stefan-hoeck/idris2-rhone-js/assets/7016973/3d56d485-bba4-4d0a-a37a-a58bac0fc21c)

Turns out it was a bad grid CSS being rendered, caused by your coding style commit [here](https://github.com/stefan-hoeck/idris2-rhone-js/commit/42f6d053e586f46f75199d5fd2ab328789f5b254#diff-e77b07bf13f790050a205b2b9dc057ee3d6638a8bab5b4a41b4559a490e06857L65):
The quotes are really necessary in this case. 😃 

Keep up your great work, Stefan! I'm really enjoying this library so far. 